### PR TITLE
DESCRIPTION format fixed for dependencies

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,12 +3,13 @@ Title: Makes QR codes
 Version: 0.0.1.9000
 Authors@R: c(person("Bob", "Rudis", email = "bob@rudis.net", role = c("aut", "cre")))
 Description: Uses libqrencode to make QR codes
-Depends: R (>= 3.1.0)
+Depends:
+    R (>= 3.1.0),
+    raster
 License: MIT + file LICENSE
 LazyData: true
 Suggests: testthat
 LinkingTo: Rcpp
-Depends: raster
 Imports: Rcpp, base64enc, png
 URL: http://github.com/hrbrmstr/qrencoder
 BugReports: https://github.com/hrbrmstr/qrencoder/issues


### PR DESCRIPTION
This fixes the error that causes R to look for a package named Depends on package install.

Building it still resulted in a compilation error though
